### PR TITLE
PHP7 compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 all:
-	gcc -Wall -Wno-unused-label -Wno-unused-function -Wno-unused-variable -O2 -shared -fpic  lmdb-php_wrap.c -I/usr/local/include/php/Zend/ -I/usr/local/include/php/TSRM/ -I/usr/local/include/php/ -I/usr/local/include/php/main/ -I/usr/include/php5/Zend/ -I/usr/include/php5/ -I/usr/include/php5/TSRM/ -I/usr/include/php5/main/ -llmdb -o lmdb-php.so
+	#gcc -Wall -Wno-unused-label -Wno-unused-function -Wno-unused-variable -O2 -shared -fpic  lmdb-php_wrap.c -I/usr/local/include/php/Zend/ -I/usr/local/include/php/TSRM/ -I/usr/local/include/php/ -I/usr/local/include/php/main/ -I/usr/include/php5/Zend/ -I/usr/include/php5/ -I/usr/include/php5/TSRM/ -I/usr/include/php5/main/ -llmdb -o lmdb-php.so
+	gcc -shared -fpic -Wall -Wno-unused-label -Wno-unused-function -Wno-unusued-variable  lmdb-php_wrap.c `php-config --includes` -llmdb -o lmdb.so
 
 swig-php5:
 	swig -php5 -Wall lmdb-php.i

--- a/lmdb-php.i
+++ b/lmdb-php.i
@@ -2,7 +2,7 @@
 %include exception.i    
 
 %{
-#include "lmdb.h"
+#include "/usr/include/lmdb.h"
 %}
 
 %ignore mdb_env_create;
@@ -30,7 +30,7 @@
 %ignore mdb_env_set_userctx;
 #endif
 
-%include "lmdb.h"
+%include "/usr/include/lmdb.h"
 
 %newobject mdb_env_create_swig;
 %newobject mdb_env_open_swig;
@@ -75,7 +75,7 @@
  */
 %typemap(out) MDB_val *mdb_val_data {
     if ($1->mv_size) {
-        ZVAL_STRINGL($result, $1->mv_data, $1->mv_size, 1);
+        ZVAL_STRINGL($result, $1->mv_data, $1->mv_size);
     } else {
         ZVAL_EMPTY_STRING($result);
     }


### PR DESCRIPTION
This patch enables a broader PHP compatibility through SWIG. 

The SWIG interface file contains a reference to "lmdb.h" which would not exist as a part of this repository, changed to point to liblmdb's lmdb.h.

ZVAL_STRINGL only accepts three arguments in PHP7+. This change has not been tested against <7, however PHP <7 is no longer supported by PHP at large.